### PR TITLE
use alpine for static linking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,41 +29,44 @@ jobs:
           ADD_TAG=""
           tags="$(git ls-remote --tags $APP_REPO | grep 'v[1-9]\.[0-9]*\.[0-9]*$' | awk -F'tags/' '{print $2}' | sort -t. -k1,1n -k2,2n -k3,3n)"
           new_tags="$(printf "%s" "$tags"| sed -n '{/\.0$/{g;p}};h' | tail -4) $(printf "%s" "$tags" | tail -1)"
-          echo -e "[Tags] $new_tags"
+          echo "::debug::[Tags] $new_tags"
           
           for t in $new_tags; do
             echo "[check] $t"
             b=$(echo "${APP_VERSION}" | grep -w ${t} | wc -l)
             if [[ $b == 0 ]]; then
-              echo "[Build] $t"
+              echo "::group::[Build] $t"
               git clone -q --depth=1 --branch $t --progress $APP_REPO
-              cd ${APP}
+              pushd ${APP}
               git checkout -b $t $t
               git branch
               
-              # golang:1.16.15-buster
-              docker pull golang:1.16.15-buster
-              docker run --rm -t -v $PWD:/build golang:1.16.15-buster sh -c "apt-get update && apt-get install -y libgpgme-dev libbtrfs-dev liblvm2-dev && cd /build && CGO_ENABLE=0 GO111MODULE=on GOOS=linux GOARCH=amd64 go build -mod=vendor '-buildmode=pie' -ldflags '-extldflags -static' -gcflags '' -tags 'exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -o ./bin/skopeo-linux-amd64 ./cmd/skopeo && md5sum ./bin/skopeo-linux-amd64 > ./bin/skopeo-linux-amd64.md5"
+              # golang:1.19.2-alpine3.16
+              docker pull golang:1.19.2-alpine3.16
+              docker run --rm -t -v $PWD:/build golang:1.19.2-alpine3.16 sh -c "apk update && apk add gpgme btrfs-progs-dev llvm13-dev gcc musl-dev && cd /build && CGO_ENABLE=0 GO111MODULE=on GOOS=linux GOARCH=amd64 go build -mod=vendor '-buildmode=pie' -ldflags '-extldflags -static' -gcflags '' -tags 'exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -o ./bin/skopeo-linux-amd64 ./cmd/skopeo && md5sum ./bin/skopeo-linux-amd64 > ./bin/skopeo-linux-amd64.md5 && sha256sum ./bin/skopeo-linux-amd64 > ./bin/skopeo-linux-amd64.sha256"
               
-              docker run --rm -t -v $PWD:/build golang:1.16.15-buster sh -c "apt-get update && apt-get install -y libgpgme-dev libbtrfs-dev liblvm2-dev && cd /build && CGO_ENABLE=0 GO111MODULE=on GOOS=linux GOARCH=arm64 go build -mod=vendor '-buildmode=pie' -ldflags '-extldflags -static' -gcflags '' -tags 'exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -o ./bin/skopeo-linux-arm64 ./cmd/skopeo && md5sum ./bin/skopeo-linux-arm64 > ./bin/skopeo-linux-arm64.md5"
+              docker run --rm -t -v $PWD:/build golang:1.19.2-alpine3.16 sh -c "apk update && apk add gpgme btrfs-progs-dev llvm13-dev gcc musl-dev && cd /build && CGO_ENABLE=0 GO111MODULE=on GOOS=linux GOARCH=arm64 go build -mod=vendor '-buildmode=pie' -ldflags '-extldflags -static' -gcflags '' -tags 'exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -o ./bin/skopeo-linux-arm64 ./cmd/skopeo && md5sum ./bin/skopeo-linux-arm64 > ./bin/skopeo-linux-arm64.md5 && sha256sum ./bin/skopeo-linux-arm64 > ./bin/skopeo-linux-arm64.sha256"
               ls -al bin/
               cd ../
               ls -al ./
               ADD_TAG=$t
               
-              echo "[Push file]"
+              echo "::debug::[Push file]"
               echo "${t}" >> version.txt
               git config --global user.email "lework@yeah.net"
               git config --global user.name "lework"
               git config --global --add safe.directory /github/workspace
               git add version.txt
               git commit -m "$APP $ADD_TAG (Github Actions Automatically Built in `date +"%Y-%m-%d %H:%M"`)"
-              echo "::set-output name=ADD_TAG::${ADD_TAG}"
+              echo "ADD_TAG=${ADD_TAG}" >> $GITHUB_OUTPUT
+              echo "::endgroup::"
+              popd
               break
             else
-              echo "[skip] $t"
+              echo "::debug::[skip] $t"
             fi
           done
+          cat ./skopeo/bin/skopeo-linux-{amd64,arm64}.{md5,sha256} > CHECKSUMS.txt
       - name: Push changes
         uses: ad-m/github-push-action@master
         if: ${{ steps.build_skopeo.outputs.ADD_TAG != '' }}
@@ -79,5 +82,8 @@ jobs:
           files: |
             ./skopeo/bin/skopeo-linux-amd64
             ./skopeo/bin/skopeo-linux-amd64.md5
+            ./skopeo/bin/skopeo-linux-amd64.sha256
             ./skopeo/bin/skopeo-linux-arm64
             ./skopeo/bin/skopeo-linux-arm64.md5
+            ./skopeo/bin/skopeo-linux-arm64.sha256
+          body_path: ./CHECKSUMS.txt


### PR DESCRIPTION
As explained in #1 this PR changes the build image to an alpine base so that the resulting static binary is linked against musl-libc thus avoiding a crash when pushing images to cri-o runtimes.

Fixes: #1 