### PR TITLE
Add support for Darwin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,15 @@ jobs:
               
               # golang:1.19.2-alpine3.16
               docker pull golang:1.19.2-alpine3.16
+              # Linux builds
               docker run --rm -t -v $PWD:/build golang:1.19.2-alpine3.16 sh -c "apk update && apk add gpgme btrfs-progs-dev llvm13-dev gcc musl-dev && cd /build && CGO_ENABLE=0 GO111MODULE=on GOOS=linux GOARCH=amd64 go build -mod=vendor '-buildmode=pie' -ldflags '-extldflags -static' -gcflags '' -tags 'exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -o ./bin/skopeo-linux-amd64 ./cmd/skopeo && md5sum ./bin/skopeo-linux-amd64 > ./bin/skopeo-linux-amd64.md5 && sha256sum ./bin/skopeo-linux-amd64 > ./bin/skopeo-linux-amd64.sha256"
               
               docker run --rm -t -v $PWD:/build golang:1.19.2-alpine3.16 sh -c "apk update && apk add gpgme btrfs-progs-dev llvm13-dev gcc musl-dev && cd /build && CGO_ENABLE=0 GO111MODULE=on GOOS=linux GOARCH=arm64 go build -mod=vendor '-buildmode=pie' -ldflags '-extldflags -static' -gcflags '' -tags 'exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -o ./bin/skopeo-linux-arm64 ./cmd/skopeo && md5sum ./bin/skopeo-linux-arm64 > ./bin/skopeo-linux-arm64.md5 && sha256sum ./bin/skopeo-linux-arm64 > ./bin/skopeo-linux-arm64.sha256"
+              
+              # Darwin builds
+              docker run --rm -t -v $PWD:/build golang:1.19.2-alpine3.16 sh -c "apk update && apk add gpgme btrfs-progs-dev llvm13-dev gcc musl-dev && cd /build && CGO_ENABLE=0 GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -mod=vendor -gcflags '' -tags 'exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -o ./bin/skopeo-darwin-amd64 ./cmd/skopeo && md5sum ./bin/skopeo-darwin-amd64 > ./bin/skopeo-darwin-amd64.md5 && sha256sum ./bin/skopeo-darwin-amd64 > ./bin/skopeo-darwin-amd64.sha256"
+              
+              docker run --rm -t -v $PWD:/build golang:1.19.2-alpine3.16 sh -c "apk update && apk add gpgme btrfs-progs-dev llvm13-dev gcc musl-dev && cd /build && CGO_ENABLE=0 GO111MODULE=on GOOS=darwin GOARCH=arm64 go build -mod=vendor -gcflags '' -tags 'exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp' -o ./bin/skopeo-darwin-arm64 ./cmd/skopeo && md5sum ./bin/skopeo-darwin-arm64 > ./bin/skopeo-darwin-arm64.md5 && sha256sum ./bin/skopeo-darwin-arm64 > ./bin/skopeo-darwin-arm64.sha256"
               ls -al bin/
               cd ../
               ls -al ./
@@ -59,7 +65,7 @@ jobs:
               git add version.txt
               git commit -m "$APP $ADD_TAG (Github Actions Automatically Built in `date +"%Y-%m-%d %H:%M"`)"
               echo "ADD_TAG=${ADD_TAG}" >> $GITHUB_OUTPUT
-              cat ./skopeo/bin/skopeo-linux-{amd64,arm64}.{md5,sha256} > CHECKSUMS.txt
+              cat ./skopeo/bin/skopeo-{darwin,linux}-{amd64,arm64}.{md5,sha256} > CHECKSUMS.txt
               echo "::endgroup::"
               popd
               break
@@ -86,4 +92,10 @@ jobs:
             ./skopeo/bin/skopeo-linux-arm64
             ./skopeo/bin/skopeo-linux-arm64.md5
             ./skopeo/bin/skopeo-linux-arm64.sha256
+            ./skopeo/bin/skopeo-darwin-amd64
+            ./skopeo/bin/skopeo-darwin-amd64.md5
+            ./skopeo/bin/skopeo-darwin-amd64.sha256
+            ./skopeo/bin/skopeo-darwin-arm64
+            ./skopeo/bin/skopeo-darwin-arm64.md5
+            ./skopeo/bin/skopeo-darwin-arm64.sha256
           body_path: ./CHECKSUMS.txt


### PR DESCRIPTION
Fixes #3 -- I don't have access to Mac to validate these builds completely but `copy` and `--help` work at least when others have looked. Not sure if you want to take on the maintenance, or I should keep it as a fork. It's a bit iffy with Mac due to not supporting static linking, so I think these will always be "best effort" in terms of portability. 

I cleared out `version.txt` and got this release: https://github.com/tgolsson/skopeo-binary/releases/tag/v1.9.3 which seems to work as expected. 